### PR TITLE
Doesn't work deps-with-modules tech with files tech

### DIFF
--- a/techs/deps-with-modules.js
+++ b/techs/deps-with-modules.js
@@ -132,7 +132,7 @@ module.exports = inherit(require('enb/lib/tech/base-tech'), {
                             cache.cacheFileInfo('deps-file', depsTargetPath);
                             cache.cacheFileInfo('bemdecl-file', bemdeclSourcePath);
                             cache.cacheFileList('deps-file-list', depFiles);
-                            _this.node.resolveTarget(depsTarget, resolvedDeps);
+                            _this.node.resolveTarget(depsTarget, { deps: resolvedDeps });
                         });
                     });
                 });


### PR DESCRIPTION
The `files` tech is broken after `deps-with-modules`:
```
20:48:25.379 - build started
20:48:25.386 - [rebuild] [bundles/common/yamoney-lib/yamoney-lib.bemdecl.js] file-provider
20:48:25.392 - [rebuild] [bundles/common/yamoney-lib/yamoney-lib.levels] levels
20:48:25.400 - [rebuild] [bundles/common/yamoney-lib/yamoney-lib.deps.js] deps-with-modules
20:48:25.401 - [failed] [bundles/common/yamoney-lib/yamoney-lib.files] files
20:48:25.401 - [failed] [bundles/common/yamoney-lib/yamoney-lib.browser.js] browser-js
20:48:25.401 - build failed
TypeError: Cannot read property 'length' of undefined
    at /home/rakchaev/job/makeup/bem/node_modules/enb-bem-techs/techs/files.js:114:55
    at Array.0 (/home/rakchaev/job/makeup/bem/node_modules/enb-bem-techs/node_modules/vow/lib/vow.js:699:56)
    at Object.callFns [as _onImmediate] (/home/rakchaev/job/makeup/bem/node_modules/enb-bem-techs/node_modules/vow/lib/vow.js:23:35)
    at processImmediate [as _immediateCallback] (timers.js:345:15)

```

Simple example of configuration:
```js
'use strict';

var bemTechs = require('enb-bem-techs');
var fileProvider = require('enb/techs/file-provider');
var browserJs = require('enb-diverse-js/techs/browser-js');
var depsWithModules = require('enb-modules/techs/deps-with-modules');

module.exports = function(config) {
	config.nodes('bundles/common', function(nodeConfig) {
		nodeConfig.addTechs([
			[ bemTechs.levels, { levels: ['blocks/common'] } ],
			// Build deps file from bemdecl
			[ fileProvider, { target: '?.bemdecl.js' } ],
			depsWithModules,
			// Build files from deps file and levels
			bemTechs.files,
			// Build js
			browserJs
		]);

		nodeConfig.addTargets(['?.browser.js']);
	});
};

```